### PR TITLE
Editor fixes for Octode

### DIFF
--- a/docs/OctodeUserGuide.md
+++ b/docs/OctodeUserGuide.md
@@ -15,6 +15,7 @@ The Text Editor is the heart of developing Octo programs, and your jumping-off p
 The following keyboard shortcuts are available:
 
 - Arrow keys move the cursor by one character.
+- `Ctrl`+Arrow keys move the cursor by entire spans of characters or whitespace.
 - `Home`/`End` move the cursor to the beginning or end of the line, respectively.
 - `PageUp`/`PageDown` move the cursor vertically by a screenful.
 - Holding `Shift` while using arrow keys, `Home`, `End`, `PageUp`, or `PageDown` will select a region of text.

--- a/src/octo_util.h
+++ b/src/octo_util.h
@@ -428,7 +428,8 @@ input_events input={0,-1,-1,0,-1,-1,0,{0},0};
 void events_queue(SDL_Event*e){
   if(e->type==SDL_KEYDOWN){
     int code=e->key.keysym.sym;
-    if(code==SDLK_LSHIFT||code==SDLK_RSHIFT)input.is_shifted++;
+    if(code==SDLK_LSHIFT)input.is_shifted|=1;
+    if(code==SDLK_RSHIFT)input.is_shifted|=2;
   }
   if(e->type==SDL_KEYUP){
     int code =e->key.keysym.sym;
@@ -467,7 +468,8 @@ void events_queue(SDL_Event*e){
     if(code==SDLK_HOME)input.events[EVENT_HOME]=1;
     if(code==SDLK_END )input.events[EVENT_END ]=1;
     if(code==SDLK_b&&cmd)input.events[EVENT_FULLSCREEN]=1;
-    if(code==SDLK_LSHIFT||code==SDLK_RSHIFT)input.is_shifted--;
+    if(code==SDLK_LSHIFT)input.is_shifted&=~1;
+    if(code==SDLK_RSHIFT)input.is_shifted&=~2;
     if(code==SDLK_i)input.events[EVENT_INTERRUPT]=1;
     if(code==SDLK_o)input.events[EVENT_STEP]=1;
     if(code==SDLK_m)input.events[EVENT_TOGGLE_MONITORS]=1;


### PR DESCRIPTION
Fix permanently sticking shift state caused by repeating shift down events being raised.
Fix '@' being pasted at the end of every line by ignoring '\r' characters in line endings.

Enhance editor navigation with Ctrl+Arrow to allow jumping by whole words/whitespace runs.
Add this key combination to the documentation.