### PR TITLE
Add CMake build file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 build/*
 leftovers/*
 **/.DS_Store
+.vs/*
+out/*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,9 @@ cmake_minimum_required(VERSION 3.21)
 
 project(c-octo VERSION 1.2 LANGUAGES C)
 
-if(NOT WIN32)
+if(WIN32)
+  set(INSTALLDIR .)
+else()
   set(INSTALLDIR bin)
 endif()
 
@@ -16,7 +18,7 @@ if(UNIX AND NOT APPLE)
 endif()
 
 if(MSVC)
-  add_compile_options(/Wall) #MSVC uses /Wall as the highest warning level, includes /W4 and more. 
+  add_compile_options(/Wall) # MSVC uses /Wall as the highest warning level, includes /W4 and more.
   #add_compile_options(/Wall /WX) # MSVC reports multiple errors that presumably other platforms don't, /WX is the equivalent to -Werror but means builds cannot complete under MSVC with an equivalent to the provided Makefile
 else()
   add_compile_options(-Wall -Werror -Wextra)
@@ -38,6 +40,11 @@ if(SDL2_FOUND)
   add_executable(octo-de src/octo_de.c)
   target_link_libraries(octo-de PRIVATE SDL2::SDL2 SDL2::SDL2main)
   install(TARGETS octo-cli octo-run octo-de DESTINATION ${INSTALLDIR})
+
+  if(MSVC)
+    # default is to dynamically link SDL2, MSVC copies the file to the build directory but we need to copy it on to the install directory manually.
+    install(FILES ${CMAKE_BINARY_DIR}/SDL2$<$<CONFIG:Debug>:d>.dll DESTINATION ${INSTALLDIR})
+  endif()
 else()
   message("SDL2 could not be found, only Octo-cli will be built.")
   install(TARGETS octo-cli DESTINATION ${INSTALLDIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,44 @@
+cmake_minimum_required(VERSION 3.21)
+
+project(c-octo VERSION 1.2 LANGUAGES C)
+
+if(NOT WIN32)
+  set(INSTALLDIR bin)
+endif()
+
+add_compile_definitions(VERSION="${PROJECT_VERSION}")
+
+if(UNIX AND NOT APPLE)
+  set(CMAKE_C_STANDARD 99)
+  set(CMAKE_C_STANDARD_REQUIRED)
+
+  add_compile_options(-lm)
+endif()
+
+if(MSVC)
+  add_compile_options(/Wall) #MSVC uses /Wall as the highest warning level, includes /W4 and more. 
+  #add_compile_options(/Wall /WX) # MSVC reports multiple errors that presumably other platforms don't, /WX is the equivalent to -Werror but means builds cannot complete under MSVC with an equivalent to the provided Makefile
+else()
+  add_compile_options(-Wall -Werror -Wextra)
+endif()
+
+if(APPLE)
+  add_compile_options(-Wpedantic)
+elseif(NOT MSVC)
+  add_compile_options(-Wno-format-truncation)
+endif()
+
+add_executable(octo-cli src/octo_cli.c)
+
+find_package(SDL2)
+
+if(SDL2_FOUND)
+  add_executable(octo-run src/octo_run.c)
+  target_link_libraries(octo-run PRIVATE SDL2::SDL2 SDL2::SDL2main)
+  add_executable(octo-de src/octo_de.c)
+  target_link_libraries(octo-de PRIVATE SDL2::SDL2 SDL2::SDL2main)
+  install(TARGETS octo-cli octo-run octo-de DESTINATION ${INSTALLDIR})
+else()
+  message("SDL2 could not be found, only Octo-cli will be built.")
+  install(TARGETS octo-cli DESTINATION ${INSTALLDIR})
+endif()

--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -1,0 +1,26 @@
+﻿{
+  "configurations": [
+    {
+      "name": "x64-Debug",
+      "generator": "Ninja",
+      "configurationType": "Debug",
+      "inheritEnvironments": [ "msvc_x64_x64" ],
+      "buildRoot": "${projectDir}\\out\\build\\${name}",
+      "installRoot": "${projectDir}\\out\\install\\${name}",
+      "cmakeCommandArgs": "",
+      "buildCommandArgs": "",
+      "ctestCommandArgs": ""
+    },
+    {
+      "name": "x64-Release",
+      "generator": "Ninja",
+      "configurationType": "Release",
+      "inheritEnvironments": [ "msvc_x64_x64" ],
+      "buildRoot": "${projectDir}\\out\\build\\${name}",
+      "installRoot": "${projectDir}\\out\\install\\${name}",
+      "cmakeCommandArgs": "",
+      "buildCommandArgs": "",
+      "ctestCommandArgs": ""
+    }
+  ]
+}

--- a/docs/BuildGuide.md
+++ b/docs/BuildGuide.md
@@ -64,8 +64,11 @@ cp octo.rc ~/.octo.rc
 
 Windows (MSVC)
 --------------
-Install SDL2 somewhere convenient, and create a project which links against and includes it appropriately:
+Recent versions of Visual Studio (2017 or later) will recognise the CMakeLists.txt file and generate a project when opening the c-octo directory. 64 bit configurations are provided by default, if performing a 32 bit build instead you'll need to install the x86 target (if using vcpkg)
 
+If you wish to use `octo-de` or `octo-run` you will need to install SDL2. Using [vcpkg](https://vcpkg.io/) with the visual studio integration makes the build process fairly seamless (follow [the vcpkg getting startd guide](https://vcpkg.io/en/getting-started.html) then run `vcpkg install SDL2:x64-windows`), otherwise you will need to ensure SDL2 is known to CMake.
+
+If you're using an older version of the IDE that doesn't support CMake you'll need to install SDL2 somewhere convenient, then create a project which links against and includes it appropriately:
 - Project -> Properties -> Configuration Properties -> VC++ Directories -> Include Directories -> Edit -> add the path to the `include`s.
 - Project -> Properties -> Configuration Properties -> VC++ Directories -> Library Directories -> Edit -> add the path to the `libs`.
 - Project -> Properties -> Configuration Properties -> C/C++ -> Preprocessor -> add `_CRT_SECURE_NO_WARNINGS;` to suppress complaints about using `fopen()`.


### PR DESCRIPTION
This enables MSVC to open and build the project using vcpkg installed SDL2 (if available). Defaults to only building octo-cli otherwise.

The build file has been set up to mimic the existing Makefile as much as possible, so the C standard version is only specified for non-Apple Unix environments, and warning levels are set per platform.

MSVC does not use "treat warnings as errors" (/WX) due to a significant number of warnings regarding variable shadowing, functions with void parameters, and spectre vulnerabilities... Could probably go back to /W4 instead of /Wall but other platforms were using pedantic warnings so figured it was best to be consistent with the warning level more than how the compiler reacts.