### PR TITLE
Initialize seed from time to address #10

### DIFF
--- a/src/octo_de.c
+++ b/src/octo_de.c
@@ -1602,6 +1602,7 @@ int main(int argc,char*argv[]){
   SDL_JoystickEventState(SDL_ENABLE);
   SDL_Joystick*joy=NULL;
   audio_init(&emu);
+  random_init();
 
   SDL_Event e; state.running=1;
   while(state.running&&SDL_WaitEvent(&e)){

--- a/src/octo_run.c
+++ b/src/octo_run.c
@@ -54,6 +54,7 @@ int main(int argc, char* argv[]){
   SDL_JoystickEventState(SDL_ENABLE);
   SDL_Joystick*joy=NULL;
   audio_init(&emu);
+  random_init();
 
   SDL_Event e;
   while(SDL_WaitEvent(&e)){

--- a/src/octo_util.h
+++ b/src/octo_util.h
@@ -6,6 +6,8 @@
 *  used by octo-run and octo-de.
 *
 **/
+#include <time.h>  // time()
+#include <stdlib.h> // srand()
 
 #define MAX(a,b)          (a>b?a:b)
 #define BLACK             0xFF000000
@@ -1023,6 +1025,10 @@ void emu_step(octo_emulator*emu,octo_program*prog){
   }
   if(emu->dt>0)emu->dt--;
   if(emu->st>0)emu->st--,emu->had_sound=1;
+}
+
+void random_init() {
+  srand(time(NULL));
 }
 
 /**


### PR DESCRIPTION
Closes #10. 

Assumes adding a seed override CLI option isn't in scope for the ticket.

Built and tested on Lubuntu 20.04 LTS per the Ubuntu build instructions.